### PR TITLE
Fixed parsing of the datastructure containing null values.

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -99,6 +99,15 @@ class DaikinCloudDevice {
     }
 
     /**
+     * Get the timestamp when data were last updated
+     *
+     * @returns {Date} Last updated timestamp
+     */
+     isCloudConnectionUp() {
+        return this.desc.isCloudConnectionUp.value;
+    }
+
+    /**
      * Get a current data object (includes value and meta information).
      * Without any parameter the full internal data structure is returned and
      * can be further detailed by sending parameters

--- a/lib/device.js
+++ b/lib/device.js
@@ -25,11 +25,12 @@ class DaikinCloudDevice {
      */
     _traverseDatapointStructure(obj, data, pathPrefix) {
         data = data || {};
+        obj = obj || [];
         pathPrefix = pathPrefix || '';
 
         //console.log('ENTER: ' + pathPrefix);
         Object.keys(obj).forEach(sub => {
-            const subKeys = Object.keys(obj[sub]);
+            const subKeys = (sub == null || obj[sub] == null) ? [] : Object.keys(obj[sub]);
             if (sub === 'meta' || subKeys.includes('value') || subKeys.includes('settable') || subKeys.includes('unit')) { // we found end leaf
                 //console.log('FINAL ' + pathPrefix + '/' + sub);
                 data[pathPrefix + '/' + sub] = obj[sub];


### PR DESCRIPTION
In some cases of a fresh installation, the API returns lots of nulls. For example


```
	"consumptionData": {
					"settable": false,
					"requiresReboot": false,
					"ref": "#consumptionData",
					"value": {
						"electrical": {
							"heating": {
								"d": [
									3,
									3,
									3,
									4,
									3,
									4,
									3,
									3,
									4,
									3,
									2,
									3,
									2,
									3,
									4,
									3,
									3,
									2,
									4,
									null,
									null,
									null,
									null,
									null
								],
								"w": [
									12,
									14,
									18,
									39,
									32,
									34,
									33,
									36,
									38,
									21,
									null,
									null,
									null,
									null
								],
								"m": [
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									110,
									3595,
									1451,
									309,
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									null,
									null
								]
							}
						}
					}
				},
```