### PR TITLE
Handle responses without body

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class DaikinCloudController extends EventEmitter {
             try {
                 return JSON.parse(res.body.toString());
             } catch {
-                return res.body.toString();
+                return (res.body && res.body.toString()) || true;
             }
         }
         if (res.statusCode === 204) {
@@ -250,7 +250,7 @@ class DaikinCloudController extends EventEmitter {
         }
         if (!refreshed && res.statusCode === 401) { // Refresh needed
             await this.refreshAccessToken();
-            return this.doBearerRequest(resourceUrl, options,true);
+            return this.doBearerRequest(resourceUrl, options, true);
         }
         const err = new Error('Communication failed ' + res.statusCode);
         err.response = res;


### PR DESCRIPTION
**What's the problem?**

Making requests that responds with `HTTP 200` without a body throws due to naive property reading.

```bash
TypeError: Cannot read property 'toString' of undefined
```

**What's changed?**

Inline checking that `res.body` is truthy before invoking `res.body.toString`. In the case that we don't get a response body, return `true` like we do for `HTTP 204` responses.

**How can this be verified?**

Should no longer throw when receiving a `HTTP 200` response without body. Tested successfully in my environment.