### PR TITLE
Update refresh token

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ class DaikinCloudController extends EventEmitter {
         if (response.body && response.body.AuthenticationResult && response.body.AuthenticationResult.AccessToken && response.body.AuthenticationResult.TokenType === 'Bearer') {
             this.tokenSet.access_token = response.body.AuthenticationResult.AccessToken;
             this.tokenSet.id_token = response.body.AuthenticationResult.IdToken;
-            this.tokenSet.access_token = response.body.AuthenticationResult.AccessToken;
+            this.tokenSet.refresh_token = response.body.AuthenticationResult.RefreshToken;
             this.tokenSet.expires_at = ~~(Date.now() / 1000) + response.body.AuthenticationResult.ExpiresIn * 1000;
             this.emit('token_update', this.tokenSet);
             return this.tokenSet;


### PR DESCRIPTION
**What's the problem?**

> HTTPError: Response code 400 (Bad Request)

```json
{
  "__type": "NotAuthorizedException",
  "message": "Refresh Token has expired"
}
```

**What's changed?**

Update and emit the updated tokens including refresh token when received in refresh response. Looks like this was a typo as L205===L207.

**How can this be verified?**

Following spec: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AuthenticationResultType.html#CognitoUserPools-Type-AuthenticationResultType-RefreshToken