### PR TITLE
Default values for bind address, bind port and redirect URI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
+        "ip": "^2.0.1",
         "openid-client": "^5.6.5"
       },
       "devDependencies": {
         "@alcalzone/release-script": "^3.7.0",
+        "@types/ip": "^1.1.3",
         "@types/node": "^20.14.9",
         "pkg": "^5.8.1",
         "typescript": "~5.5.3"
@@ -308,6 +310,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@types/ip": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
+      "integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -1015,6 +1026,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/is-core-module": {
       "version": "2.9.0",
@@ -2346,6 +2362,15 @@
         "fastq": "^1.6.0"
       }
     },
+    "@types/ip": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
+      "integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "20.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
@@ -2856,6 +2881,11 @@
         "from2": "^2.3.0",
         "p-is-promise": "^3.0.0"
       }
+    },
+    "ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "is-core-module": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "node": ">=18.2"
   },
   "dependencies": {
+    "ip": "^2.0.1",
     "openid-client": "^5.6.5"
   },
   "devDependencies": {
     "@alcalzone/release-script": "^3.7.0",
+    "@types/ip": "^1.1.3",
     "@types/node": "^20.14.9",
     "pkg": "^5.8.1",
     "typescript": "~5.5.3"

--- a/src/example.ts
+++ b/src/example.ts
@@ -26,11 +26,11 @@ const controller = new DaikinCloudController({
     /* OIDC client secret */
     oidcClientSecret: oidc_client_secret,
     /* Network interface that the HTTP server should bind to. Bind to all interfaces for convenience, please limit as needed to single interfaces! */
-    oidcCallbackServerBindAddr: '0.0.0.0',
+    // oidcCallbackServerBindAddr: '0.0.0.0',
     /* port that the HTTP server should bind to */
-    oidcCallbackServerPort: 8765,
+    // oidcCallbackServerPort: 8765,
     /* OIDC Redirect URI */
-    oidcCallbackServerExternalAddress: 'daikin.local',
+    // oidcCallbackServerExternalAddress: 'daikin.local',
     //oidcCallbackServerBaseUrl: 'https://daikin.local:8765', // or use local IP address where server is reachable
     /* path of file used to cache the OIDC tokenset */
     oidcTokenSetFilePath: resolve(homedir(), '.daikin-controller-cloud-tokenset'),

--- a/src/onecta/oidc-callback-server.ts
+++ b/src/onecta/oidc-callback-server.ts
@@ -1,84 +1,120 @@
+
 import type { IncomingMessage, ServerResponse } from 'node:http';
+
 import { resolve } from 'node:path';
 import { createServer, Server } from 'node:https';
 import { readFile } from 'node:fs/promises';
+
+import { address } from 'ip';
+
 import { OnectaClientConfig, onecta_oidc_auth_thank_you_html } from './oidc-utils.js';
+import { AddressInfo } from 'node:net';
 
-export type OnectaOIDCCallbackServerRequestListener<
-    Request extends typeof IncomingMessage = typeof IncomingMessage,
-    Response extends typeof ServerResponse = typeof ServerResponse,
-> = (server: Server, req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+export class OnectaOIDCCallbackServer {
 
-/**
- * Creates and starts a HTTPS server
- */
-export const startOnectaOIDCCallbackServer = async (config: OnectaClientConfig, oidc_state: string, auth_url: string): Promise<string> => {
-    if (!config.oidcCallbackServerPort || !config.oidcCallbackServerBindAddr) {
-        throw new Error('oidcCallbackServerPort and oidcCallbackServerBindAddr must be set when using the server');
+    #config: OnectaClientConfig;
+    #server: Server | null;
+    #redirectUri: string | null;
+
+    constructor(config: OnectaClientConfig) {
+        this.#config = config;
+        this.#server = null;
+        this.#redirectUri = null;
     }
-    const server = createServer({
-        key: await readFile(config.certificatePathKey ?? resolve(__dirname, '..', '..', 'cert', 'cert.key')),
-        cert: await readFile(config.certificatePathCert ?? resolve(__dirname, '..', '..', 'cert', 'cert.pem')),
-    });
-    await new Promise<void>((resolve, reject) => {
-        const cleanup = () => {
-            server.removeListener('listening', onListening);
-            server.removeListener('error', onError);
-        };
-        const onListening = () => {
-            cleanup();
-            resolve();
+
+    async listen(): Promise<string> {
+        const config = this.#config;
+        const server = createServer({
+            key: await readFile(
+                config.certificatePathKey
+                    ?? resolve(__dirname, '..', '..', 'cert', 'cert.key'),
+            ),
+            cert: await readFile(
+                config.certificatePathCert
+                    ?? resolve(__dirname, '..', '..', 'cert', 'cert.pem'),
+            ),
+        });
+        await new Promise<void>((resolve, reject) => {
+            const cleanup = () => {
+                server.removeListener('listening', onListening);
+                server.removeListener('error', onError);
+            };
+            const onListening = () => {
+                cleanup();
+                resolve();
+            }
+            const onError = (err: Error) => {
+                cleanup();
+                reject(err);
+            };
+            server.on('listening', onListening);
+            server.on('error', onError);
+            server.listen(
+                config.oidcCallbackServerPort ?? 0, 
+                config.oidcCallbackServerBindAddr ?? '0.0.0.0',
+            );
+        });
+        let callbackUrl = config.oidcCallbackServerBaseUrl;
+        if (!callbackUrl) {
+            const oidcHostname = config.oidcCallbackServerExternalAddress ?? address('public');
+            const oidcPort = config.oidcCallbackServerPort ?? (server.address() as AddressInfo).port;    
+            callbackUrl = `https://${oidcHostname}:${oidcPort}`;
         }
-        const onError = (err: Error) => {
-            cleanup();
-            reject(err);
-        };
-        server.on('listening', onListening);
-        server.on('error', onError);
-        server.listen(config.oidcCallbackServerPort, config.oidcCallbackServerBindAddr);
-    });
-    return await new Promise<string>((resolve, reject) => {
-        let timeout: NodeJS.Timeout;
-        const cleanup = () => {
-            clearTimeout(timeout);
-            server.removeListener('request', onRequest);
-            server.removeListener('error', onError);
-            server.close();
-            server.closeAllConnections();
-        };
-        const onError = (err: Error) => {
-            cleanup();
-            reject(err);
-        };
-        const onTimeout = () => {
-            cleanup();
-            reject(new Error('Authorization time out'));
-        };
-        const onAuthCode = (code: string) => {
-            cleanup();
-            resolve(code);
-        };
-        const onRequest = (req: IncomingMessage, res: ServerResponse) => {
-            const url = new URL(req.url ?? '/', config.oidcCallbackServerBaseUrl);
-            const resState = url.searchParams.get('state');
-            const authCode = url.searchParams.get('code');
-            if (resState === oidc_state && authCode) {
-                res.statusCode = 200;
-                res.write(config.onectaOidcAuthThankYouHtml ?? onecta_oidc_auth_thank_you_html);
-                res.once('finish', () => onAuthCode(authCode));
-            } else if (!resState && !authCode && (req.url ?? '/') === '/') {
-                //Redirect to auth_url
-                res.writeHead(302, {
-                    'Location': auth_url,
-                });
-            }
-            else {
-                res.statusCode = 400;
-            }
-            res.end();
-        };
-        setTimeout(onTimeout, config.oidcAuthorizationTimeoutS * 1000);
-        server.on('request', onRequest);
-        server.on('error', onError);
-    });
-};
+        this.#server = server;
+        this.#redirectUri = callbackUrl;
+        return callbackUrl;
+    }
+
+    async waitForAuthCodeAndClose(oidc_state: string, auth_url: string): Promise<string> {
+        const config = this.#config;
+        const server = this.#server;
+        if (!server?.listening) {
+            throw new Error('server is not listening');
+        }
+        return await new Promise<string>((resolve, reject) => {
+            let timeout: NodeJS.Timeout;
+            const cleanup = () => {
+                clearTimeout(timeout);
+                server.removeListener('request', onRequest);
+                server.removeListener('error', onError);
+                server.closeAllConnections();
+                server.close();
+            };
+            const onError = (err: Error) => {
+                cleanup();
+                reject(err);
+            };
+            const onTimeout = () => {
+                cleanup();
+                reject(new Error('Authorization time out'));
+            };
+            const onAuthCode = (code: string) => {
+                cleanup();
+                resolve(code);
+            };
+            const onRequest = (req: IncomingMessage, res: ServerResponse) => {
+                const url = new URL(req.url ?? '/', this.#redirectUri!);
+                const resState = url.searchParams.get('state');
+                const authCode = url.searchParams.get('code');
+                if (resState === oidc_state && authCode) {
+                    res.statusCode = 200;
+                    res.write(config.onectaOidcAuthThankYouHtml ?? onecta_oidc_auth_thank_you_html);
+                    res.once('finish', () => onAuthCode(authCode));
+                } else if (!resState && !authCode && (req.url ?? '/') === '/') {
+                    // Redirect to auth_url
+                    res.writeHead(302, {
+                        'Location': auth_url,
+                    });
+                }
+                else {
+                    res.statusCode = 400;
+                }
+                res.end();
+            };
+            setTimeout(onTimeout, config.oidcAuthorizationTimeoutS * 1000);
+            server.on('request', onRequest);
+            server.on('error', onError);
+        });
+    }
+
+}


### PR DESCRIPTION
This PR takes care of setting reasonable defaults when config options are missing:

- the callback server will bind to an OS-selected port if none is specified via config
- the callback server will bind to address `0.0.0.0` if none is specified via config
- the client will generate the OIDC redirect URI based on the port that the HTTP server has bound and the interfaces reported by the OS if none is specified via config